### PR TITLE
Concatenate messages, awaits and refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ all: $(OUT)
 
 FILES=$(shell cat files.txt)
 
+.PHONY: clean
+clean:
+	rm $(OUT)
+
 $(OUT): $(FILES)
 	-rm $@
 	zip -r9 $@ $^

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+OUT=tst-colored-sz.xpi
+all: $(OUT)
+
+FILES=$(shell cat files.txt)
+
+$(OUT): $(FILES)
+	-rm $@
+	zip -r9 $@ $^

--- a/background.js
+++ b/background.js
@@ -127,11 +127,16 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
         await browser.tabs.query({}).then(function (tabs) {
             for (const tab of tabs) {
                 let host = new URL(tab.url);
-                host = host.hostname.toString();
+                let host_str = host.hostname.toString();
+                if (host_str === undefined || host_str.length === 0) {
+                    host_str = "unknown"
+                }
                 console.log('colorize tab id ' + tab.id + ' host ' + host);
                 ColoredTabs.colorizeTab(tab.id, host);
                 host = null;
+                host_str = null;
             }
+            console.log('Finished coloring');
         }, onError);
     },
 

--- a/background.js
+++ b/background.js
@@ -127,7 +127,7 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
         });
 
         await browser.tabs.query({}).then(async function (tabs) {
-            let limit = 100;
+            let limit = 2000;
             for (const tab of tabs) {
                 if (limit-- === 0) break;
                 let host = new URL(tab.url);

--- a/background.js
+++ b/background.js
@@ -249,9 +249,7 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
             console.warn("broken host string:", s)
             return "unknown";
         }
-        const final = s.slice(0, 100);
-        // console.log("sanitization result", s, final);
-        return final;
+        return s.slice(0, 100);
     },
 
     hash(_s) {

--- a/background.js
+++ b/background.js
@@ -135,9 +135,9 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
                     host_str = "unknown"
                 }
                 if (tab.id % 10 === 0) {
-                    console.log('colorize tab id ' + tab.id + ' host ' + host);
+                    console.log('colorize tab id ' + tab.id + ' host ' + host_str);
                 }
-                ColoredTabs.colorizeTab(tab.id, host);
+                ColoredTabs.colorizeTab(tab.id, host_str);
                 host = null;
                 host_str = null;
             }

--- a/background.js
+++ b/background.js
@@ -3,72 +3,74 @@
 const TST_ID = "treestyletab@piro.sakura.ne.jp";
 
 const DEFAULT_SETTINGS = {
-  saturation: 60,
-  lightness: 70,
-  colors: 15,
-  activeSaturate: 120,
-  activeBrightness: 120,
-  activeBold: true,
-  hoverSaturate: 110,
-  hoverBrightness: 110,
-  hosts: [
-    { host: 'example.com', regexp: false, color: '#FF7700', disabled: true },
-    { host: '.*\\.google\\..*', regexp: true, color: '#7171FF', disabled: true },
-  ],
+    saturation: 60,
+    lightness: 70,
+    colors: 15,
+    activeSaturate: 120,
+    activeBrightness: 120,
+    activeBold: true,
+    hoverSaturate: 110,
+    hoverBrightness: 110,
+    hosts: [
+        {host: 'example.com', regexp: false, color: '#FF7700', disabled: true},
+        {host: '.*\\.google\\..*', regexp: true, color: '#7171FF', disabled: true},
+    ],
 };
 
-var ColoredTabs = {
-  state: {
-    'inited': false,
-  },
-
-  init() {
-    browser.storage.sync.get().then(function(settingsStored) {
-      ColoredTabs.settings = {}
-      Object.assign(ColoredTabs.settings, DEFAULT_SETTINGS, settingsStored);
-
-      ColoredTabs.state = {
-        'tabsHost': [],
-        'tabsClass': [],
+let ColoredTabs = {
+    state: {
         'inited': false,
-      };
-          // console.log(ColoredTabs.settings);
+    },
 
-      if(ColoredTabs.settings.hosts) {
-        ColoredTabs.settings.hosts.forEach(function(hostsItem) {
-          if(hostsItem.disabled !== true && hostsItem.color.length > 3) {
-            if(hostsItem.regexp == true) {
-              if(ColoredTabs.state.hostsRegexp === undefined) {
-                ColoredTabs.state.hostsRegexp = [];
-                ColoredTabs.state.hostsRegexpColor = [];
-              }
-              ColoredTabs.state.hostsRegexp.push(hostsItem.host);
-              ColoredTabs.state.hostsRegexpColor.push(hostsItem.color);
-            } else {
-              if(ColoredTabs.state.hostsMatch === undefined) {
-                ColoredTabs.state.hostsMatch = [];
-                ColoredTabs.state.hostsMatchColor = [];
-              }
-              ColoredTabs.state.hostsMatch.push(hostsItem.host);
-              ColoredTabs.state.hostsMatchColor.push(hostsItem.color);
+    init() {
+        browser.storage.sync.get().then(async function (settingsStored) {
+            ColoredTabs.settings = {}
+            Object.assign(ColoredTabs.settings, DEFAULT_SETTINGS, settingsStored);
+
+            ColoredTabs.state = {
+                'tabsHost': [],
+                'tabsClass': [],
+                'inited': false,
+                // 'hash': {},
+                'hash': new Map(),
+            };
+            // console.log(ColoredTabs.settings);
+
+            if (ColoredTabs.settings.hosts) {
+                ColoredTabs.settings.hosts.forEach(function (hostsItem) {
+                    if (hostsItem.disabled !== true && hostsItem.color.length > 3) {
+                        if (hostsItem.regexp === true) {
+                            if (ColoredTabs.state.hostsRegexp === undefined) {
+                                ColoredTabs.state.hostsRegexp = [];
+                                ColoredTabs.state.hostsRegexpColor = [];
+                            }
+                            ColoredTabs.state.hostsRegexp.push(hostsItem.host);
+                            ColoredTabs.state.hostsRegexpColor.push(hostsItem.color);
+                        } else {
+                            if (ColoredTabs.state.hostsMatch === undefined) {
+                                ColoredTabs.state.hostsMatch = [];
+                                ColoredTabs.state.hostsMatchColor = [];
+                            }
+                            ColoredTabs.state.hostsMatch.push(hostsItem.host);
+                            ColoredTabs.state.hostsMatchColor.push(hostsItem.color);
+                        }
+                    }
+                });
             }
-          }
+
+            await ColoredTabs.colorizeAllTabs();
+            browser.tabs.onUpdated.addListener(ColoredTabs.checkTabChanges);
+            browser.tabs.onRemoved.addListener(ColoredTabs.removeTabInfo)
+            //         browser.tabs.onCreated.addListener(ColoredTabs.handleCreated);
+
+            // console.log(ColoredTabs.state);
+
+            ColoredTabs.state.inited = true;
         });
-      }
-
-      ColoredTabs.colorizeAllTabs();
-      browser.tabs.onUpdated.addListener(ColoredTabs.checkTabChanges);
-      browser.tabs.onRemoved.addListener(ColoredTabs.removeTabInfo)
-  //         browser.tabs.onCreated.addListener(ColoredTabs.handleCreated);
-
-      // console.log(ColoredTabs.state);
-
-      ColoredTabs.state.inited = true;
-    });
-  },
+    },
 
 //     handleCreated(tab) {
-//       console.log("handleCreated tab id " + tab.id + " tab url " + tab.url);
+    //console.log("handleCreated tab id " + tab.id + " tab url " + tab.url);
 //       if(tab.url.indexOf('about:') === 0)
 //         return;
 //       let host = new URL(tab.url);
@@ -76,150 +78,171 @@ var ColoredTabs = {
 //       ColoredTabs.colorizeTab(tab.id, host);
 //     },
 
-  checkTabChanges(tabId, changeInfo, tab) {
-//       console.log("checkTabChanges tab id " + tabId + " tab url " + tab.url);
-//       console.log(changeInfo);
-    if(typeof changeInfo.url === 'undefined' || tab.url.indexOf('about:') === 0)
-      return;
-    let host = new URL(changeInfo.url);
-    host = host.hostname.toString();
-    if(host != ColoredTabs.state.tabsHost[tabId]) {
-      ColoredTabs.state.tabsHost[tabId] = host;
-      ColoredTabs.colorizeTab(tabId, host);
-    }
-  },
-  removeTabInfo(tabId, removeInfo) {
-//       console.log("removeTabInfo tab id " + tabId);
-    delete ColoredTabs.state.tabsHost[tabId];
-    delete ColoredTabs.state.tabsClass[tabId];
-  },
-  colorizeAllTabs() {
-//       console.log('colorizeAllTabs() start');
-    let css = `
+    checkTabChanges(tabId, changeInfo, tab) {
+        console.log("checkTabChanges tab id " + tabId + " tab url " + tab.url);
+        console.log(changeInfo);
+        if (typeof changeInfo.url === 'undefined' || tab.url.indexOf('about:') === 0)
+            return;
+        let host = new URL(changeInfo.url);
+        host = host.hostname.toString();
+        if (host !== ColoredTabs.state.tabsHost[tabId]) {
+            ColoredTabs.state.tabsHost[tabId] = host;
+            ColoredTabs.colorizeTab(tabId, host);
+        }
+    },
+    removeTabInfo(tabId, removeInfo) {
+        console.log("removeTabInfo tab id " + tabId);
+        delete ColoredTabs.state.tabsHost[tabId];
+        delete ColoredTabs.state.tabsClass[tabId];
+    },
+
+    async colorizeAllTabs() {
+        console.log('colorizeAllTabs() start');
+        let css = `
 tab-item.active tab-item-substance {filter: saturate(` + ColoredTabs.settings.activeSaturate + `%) brightness(` + ColoredTabs.settings.activeBrightness + `%);}
 tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hoverSaturate + `%) brightness(` + ColoredTabs.settings.hoverBrightness + `%);}`;
 
-    if(ColoredTabs.settings.activeBold == true) {
-      css += 'tab-item.active .label{font-weight:bold}';
-    }
-
-    for(let i = 0; i < 360; i += (360 / ColoredTabs.settings.colors)) {
-      let hue = Math.round(i);
-      css += `tab-item.coloredTabsHue` + hue + ` tab-item-substance {background-color: hsl(` + hue + `,` + ColoredTabs.settings.saturation + `%,` + ColoredTabs.settings.lightness + `%);}`;
-    }
-
-    if(ColoredTabs.state.hostsMatchColor !== undefined) {
-      ColoredTabs.state.hostsMatchColor.forEach((element, index) => css += `tab-item.coloredTabsHostMatch` + index + ` tab-item-substance {background-color: ` + element + `;}`);
-    }
-    if(ColoredTabs.state.hostsRegexpColor !== undefined) {
-      ColoredTabs.state.hostsRegexpColor.forEach((element, index) => css += `tab-item.coloredTabsHostRegexp` + index + ` tab-item-substance {background-color: ` + element + `;}`);
-    }
-    // console.log(css);
-
-    browser.runtime.sendMessage(TST_ID, {
-        type: "register-self",
-        style: css,
-    });
-
-    browser.tabs.query({}).then(function(tabs){
-      for (let tab of tabs) {
-        let host = new URL(tab.url);
-        host = host.hostname.toString();
-//           console.log('colorize tab id ' + tab.id + ' host ' + host);
-        ColoredTabs.colorizeTab(tab.id, host);
-      }
-    }, onError);
-  },
-
-  colorizeTab(tabId, host) {
-    let tabClass = null;
-    let index = null;
-    if ((ColoredTabs.state.hostsMatch !== undefined) && (index = ColoredTabs.state.hostsMatch.indexOf(host) > -1)) {
-      tabClass = 'coloredTabsHostMatch' + ColoredTabs.state.hostsMatch.indexOf(host);
-    } else if (ColoredTabs.state.hostsRegexp !== undefined) {
-      for (let i = 0; i < ColoredTabs.state.hostsRegexp.length; i++) {
-        if(host.match(ColoredTabs.state.hostsRegexp[i])) {
-          tabClass = 'coloredTabsHostRegexp' + i;
-          break;
+        if (ColoredTabs.settings.activeBold === true) {
+            css += 'tab-item.active .label{font-weight:bold}';
         }
-      }
-    }
-    if(tabClass === null) {
-      tabClass = 'coloredTabsHue' + Math.round((ColoredTabs.hash(host) % ColoredTabs.settings.colors) * (360 / ColoredTabs.settings.colors));
-    }
 
-    // console.log("colorizeTab tabId " + tabId + ", host " + host + " hash " + ColoredTabs.hash(host) + " step " + (ColoredTabs.hash(host) % ColoredTabs.settings.colors) + " tabClass " + tabClass);
+        for (let i = 0; i < 360; i += (360 / ColoredTabs.settings.colors)) {
+            let hue = Math.round(i);
+            css += `tab-item.coloredTabsHue` + hue + ` tab-item-substance {background-color: hsl(` + hue + `,` + ColoredTabs.settings.saturation + `%,` + ColoredTabs.settings.lightness + `%);}`;
+        }
 
-    if(ColoredTabs.state.tabsClass[tabId] != tabClass) {
-      browser.runtime.sendMessage(TST_ID, {
-        type:  'add-tab-state',
-        tabs:  [tabId],
-        state: tabClass,
-      });
-      if(typeof ColoredTabs.state.tabsClass[tabId] !== undefined) {
+        if (ColoredTabs.state.hostsMatchColor !== undefined) {
+            ColoredTabs.state.hostsMatchColor.forEach((element, index) => css += `tab-item.coloredTabsHostMatch` + index + ` tab-item-substance {background-color: ` + element + `;}`);
+        }
+        if (ColoredTabs.state.hostsRegexpColor !== undefined) {
+            ColoredTabs.state.hostsRegexpColor.forEach((element, index) => css += `tab-item.coloredTabsHostRegexp` + index + ` tab-item-substance {background-color: ` + element + `;}`);
+        }
+        console.log(css);
+
         browser.runtime.sendMessage(TST_ID, {
-          type:  'remove-tab-state',
-          tabs:  [tabId],
-          state: ColoredTabs.state.tabsClass[tabId],
+            type: "register-self",
+            style: css,
         });
-      }
-      ColoredTabs.state.tabsClass[tabId] = tabClass;
-    }
-  },
 
-  hash(s) {
-    for(var i=0, h=1; i<s.length; i++)
-      h=Math.imul(h+s.charCodeAt(i)|0, 2654435761);
-    return (h^h>>>17)>>>0;
-  },
+        await browser.tabs.query({}).then(function (tabs) {
+            for (const tab of tabs) {
+                let host = new URL(tab.url);
+                host = host.hostname.toString();
+                console.log('colorize tab id ' + tab.id + ' host ' + host);
+                ColoredTabs.colorizeTab(tab.id, host);
+                host = null;
+            }
+        }, onError);
+    },
+
+    // TODO can be async
+    colorizeTab(tabId, host) {
+        let tabClass = null;
+        let index = null;
+        if ((ColoredTabs.state.hostsMatch !== undefined) && (index = ColoredTabs.state.hostsMatch.indexOf(host) > -1)) {
+            // if there is a host-color relation specified
+            tabClass = 'coloredTabsHostMatch' + ColoredTabs.state.hostsMatch.indexOf(host);
+        } else if (ColoredTabs.state.hostsRegexp !== undefined) {
+            // if there is a regexp host-color relation specified
+            for (let i = 0; i < ColoredTabs.state.hostsRegexp.length; i++) {
+                if (host.match(ColoredTabs.state.hostsRegexp[i])) {
+                    tabClass = 'coloredTabsHostRegexp' + i;
+                    break;
+                }
+            }
+        } else {
+            // calculate hue color for host
+            tabClass = 'coloredTabsHue' + Math.round((ColoredTabs.hash(host) % ColoredTabs.settings.colors) * (360 / ColoredTabs.settings.colors));
+        }
+
+        // console.log("colorizeTab tabId " + tabId + ", host " + host + " hash " + ColoredTabs.hash(host) + " step " + (ColoredTabs.hash(host) % ColoredTabs.settings.colors) + " tabClass " + tabClass);
+
+        // FIXME why sending here two commands one after another, adding, and removing state?
+        if (ColoredTabs.state.tabsClass[tabId] !== tabClass) {
+            browser.runtime.sendMessage(TST_ID, {
+                type: 'add-tab-state',
+                tabs: [tabId],
+                state: tabClass,
+            });
+            if (typeof ColoredTabs.state.tabsClass[tabId] !== undefined) {
+                browser.runtime.sendMessage(TST_ID, {
+                    type: 'remove-tab-state',
+                    tabs: [tabId],
+                    state: ColoredTabs.state.tabsClass[tabId],
+                });
+            }
+            ColoredTabs.state.tabsClass[tabId] = tabClass;
+        }
+    },
+
+    hash(s) {
+        const cached_value = ColoredTabs.state.hash.get(s);
+        if (cached_value !== undefined) {
+            return cached_value;
+        }
+        let h = 0;
+        for (let i = 0, h = 1; i < s.length; i++)
+            h = Math.imul(h + s.charCodeAt(i) | 0, 2654435761);
+        const result = (h ^ h >>> 17) >>> 0;
+        ColoredTabs.state.hash.set(s, cached_value);
+        return result;
+    },
 
 }
 
 function onError(error) {
-  console.log(`Error: ${error}`);
+    console.log(`Error: ${error}`);
 }
 
 async function registerToTST() {
     try {
-      const self = await browser.management.getSelf();
-      await browser.runtime.sendMessage(TST_ID, {
-        type: "register-self",
-        name: self.id,
-        listeningTypes: ["ready", "sidebar-show", "permissions-changed"],
-      });
-    } catch(e) {
-      // Could not register
-      console.log("Tree Style Tab extension needed for TST Colored Tabs, but can't be detected. Please install or enable it.")
-      return false;
+        const self = await browser.management.getSelf();
+        await browser.runtime.sendMessage(TST_ID, {
+            type: "register-self",
+            name: self.id,
+            listeningTypes: ["ready", "sidebar-show", "permissions-changed"],
+        });
+    } catch (e) {
+        // Could not register
+        console.log("Tree Style Tab extension needed for TST Colored Tabs, but can't be detected. Please install or enable it.")
+        return false;
     }
 
     return true;
 }
 
 async function handleTSTMessage(message, sender) {
-    if(sender.id !== TST_ID) {
+    if (sender.id !== TST_ID) {
         return;
     }
-//     console.log('handleTSTMessage ' + message.type);
-//     console.log(message);
+    console.log('handleTSTMessage ' + message.type);
+    console.log(message);
 
     switch (message.type) {
         case "ready":
-          registerToTST();
-          ColoredTabs.init();
-        case "sidebar-show":
-        case "permissions-changed":
-          if(ColoredTabs.state.inited != true) {
-//             console.log('TST ready, initializing ColoredTabs');
+            // TODO worth trying again after a couple of seconds?
+            await registerToTST();
             ColoredTabs.init();
-          } else {
-//             console.log('ColoredTabs already inited, so call colorizeAllTabs');
-            ColoredTabs.colorizeAllTabs();
-          }
-          break;
+            break;
+        case "sidebar-show":
+        /* fall-through */
+        case "permissions-changed":
+            if (ColoredTabs.state.inited !== true) {
+                console.log('TST ready, initializing ColoredTabs');
+                ColoredTabs.init();
+            } else {
+                console.log('ColoredTabs already inited, so call colorizeAllTabs');
+                await ColoredTabs.colorizeAllTabs();
+            }
+            break;
     }
 }
 
-
-registerToTST();
+// TODO is this really needed?
+// registerToTST();
 browser.runtime.onMessageExternal.addListener(handleTSTMessage);
+
+
+/**
+ * Connection closed, pending request to server0.conn0.webExtensionDescriptor334, type reload failed Request stack: request@resource://devtools/shared/protocol/Front.js:300:14 generateRequestMethods/</frontProto[name]@resource://devtools/shared/protocol/Front/FrontClassWithSpec.js:47:19 reloadTemporaryExtension/<@resource://devtools/client/aboutdebugging/src/actions/debug-targets.js:166:30
+ */

--- a/background.js
+++ b/background.js
@@ -31,7 +31,6 @@ let ColoredTabs = {
                 'tabsHost': [],
                 'tabsClass': [],
                 'inited': false,
-                // 'hash': {},
                 'hash': new Map(),
                 'cache_host_tabclass': new Map(),
             };
@@ -88,6 +87,7 @@ let ColoredTabs = {
         let host = _host.hostname.toString();
         host = ColoredTabs.sanitizeHostStr(host);
         if (host !== ColoredTabs.state.tabsHost[tabId]) {
+            // if host has changed, redo the coloring
             ColoredTabs.state.tabsHost[tabId] = host;
             await ColoredTabs.colorizeTab(tabId, host);
         }

--- a/background.js
+++ b/background.js
@@ -214,8 +214,8 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
         if (cached_value !== undefined) {
             return cached_value;
         }
-        let h = 0;
-        for (let i = 0, h = 1; i < s.length; i++) {
+        let h = 0, i = 0;
+        for (i = 0, h = 1; i < s.length; i++) {
             h = Math.imul(h + s.charCodeAt(i) | 0, 2654435761);
         }
         const result = (h ^ h >>> 17) >>> 0;

--- a/background.js
+++ b/background.js
@@ -79,7 +79,7 @@ let ColoredTabs = {
 //       ColoredTabs.colorizeTab(tab.id, host);
 //     },
 
-    checkTabChanges(tabId, changeInfo, tab) {
+    async checkTabChanges(tabId, changeInfo, tab) {
         console.log("checkTabChanges tab id " + tabId + " tab url " + tab.url);
         console.log(changeInfo);
         if (typeof changeInfo.url === 'undefined' || tab.url.indexOf('about:') === 0)
@@ -89,7 +89,7 @@ let ColoredTabs = {
         host = ColoredTabs.sanitizeHostStr(host);
         if (host !== ColoredTabs.state.tabsHost[tabId]) {
             ColoredTabs.state.tabsHost[tabId] = host;
-            ColoredTabs.colorizeTab(tabId, host);
+            await ColoredTabs.colorizeTab(tabId, host);
         }
     },
     removeTabInfo(tabId, removeInfo) {
@@ -138,7 +138,7 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
                 if (tab.id % 10 === 0) {
                     console.log('colorize tab id ' + tab.id + ' host ' + host_str);
                 }
-                ColoredTabs.colorizeTab(tab.id, host_str);
+                await ColoredTabs.colorizeTab(tab.id, host_str);
                 host = null;
                 host_str = null;
             }
@@ -176,20 +176,20 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
     },
 
     // TODO can be async
-    colorizeTab(tabId, host) {
+    async colorizeTab(tabId, host) {
         let tabClass = this.getTabClass(host);
 
         // console.log("colorizeTab tabId " + tabId + ", host " + host + " hash " + ColoredTabs.hash(host) + " step " + (ColoredTabs.hash(host) % ColoredTabs.settings.colors) + " tabClass " + tabClass);
 
         // FIXME why sending here two commands one after another, adding, and removing state?
         if (ColoredTabs.state.tabsClass[tabId] !== tabClass) {
-            browser.runtime.sendMessage(TST_ID, {
+            await browser.runtime.sendMessage(TST_ID, {
                 type: 'add-tab-state',
                 tabs: [tabId],
                 state: tabClass,
             });
             if (typeof ColoredTabs.state.tabsClass[tabId] !== undefined) {
-                browser.runtime.sendMessage(TST_ID, {
+                await browser.runtime.sendMessage(TST_ID, {
                     type: 'remove-tab-state',
                     tabs: [tabId],
                     state: ColoredTabs.state.tabsClass[tabId],

--- a/background.js
+++ b/background.js
@@ -33,6 +33,7 @@ let ColoredTabs = {
                 'inited': false,
                 // 'hash': {},
                 'hash': new Map(),
+                'cache_host_tabclass': new Map(),
             };
             // console.log(ColoredTabs.settings);
 
@@ -140,10 +141,19 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
         }, onError);
     },
 
-    // TODO can be async
-    colorizeTab(tabId, host) {
-        let tabClass = null;
+    getTabClass(_host) {
+        if (typeof _host !== 'string') {
+            _host = "unknown";
+        }
+        const host = _host.slice(0, 100);
+
+        const cached_value = ColoredTabs.state.cache_host_tabclass.get(host);
+        if (cached_value !== undefined) {
+            return cached_value;
+        }
+
         let index = null;
+        let tabClass;
         if ((ColoredTabs.state.hostsMatch !== undefined) && (index = ColoredTabs.state.hostsMatch.indexOf(host) > -1)) {
             // if there is a host-color relation specified
             tabClass = 'coloredTabsHostMatch' + ColoredTabs.state.hostsMatch.indexOf(host);
@@ -159,6 +169,13 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
             // calculate hue color for host
             tabClass = 'coloredTabsHue' + Math.round((ColoredTabs.hash(host) % ColoredTabs.settings.colors) * (360 / ColoredTabs.settings.colors));
         }
+        ColoredTabs.state.cache_host_tabclass.set(host, tabClass);
+        return tabClass;
+    },
+
+    // TODO can be async
+    colorizeTab(tabId, host) {
+        let tabClass = this.getTabClass(host);
 
         // console.log("colorizeTab tabId " + tabId + ", host " + host + " hash " + ColoredTabs.hash(host) + " step " + (ColoredTabs.hash(host) % ColoredTabs.settings.colors) + " tabClass " + tabClass);
 

--- a/background.js
+++ b/background.js
@@ -173,19 +173,20 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
         return tabClass;
     },
 
-    // TODO can be async
     async colorizeTab(tabId, host) {
         let tabClass = this.getTabClass(host);
 
         // console.log("colorizeTab tabId " + tabId + ", host " + host + " hash " + ColoredTabs.hash(host) + " step " + (ColoredTabs.hash(host) % ColoredTabs.settings.colors) + " tabClass " + tabClass);
 
         // FIXME why sending here two commands one after another, adding, and removing state?
+        // change color class, if it is different than last set (including not set)
         if (ColoredTabs.state.tabsClass[tabId] !== tabClass) {
             await browser.runtime.sendMessage(TST_ID, {
                 type: 'add-tab-state',
                 tabs: [tabId],
                 state: tabClass,
             });
+            // send this message, if this is the first time
             if (typeof ColoredTabs.state.tabsClass[tabId] !== undefined) {
                 await browser.runtime.sendMessage(TST_ID, {
                     type: 'remove-tab-state',

--- a/background.js
+++ b/background.js
@@ -126,7 +126,7 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
             style: css,
         });
 
-        await browser.tabs.query({}).then(function (tabs) {
+        await browser.tabs.query({}).then(async function (tabs) {
             let limit = 100;
             for (const tab of tabs) {
                 if (limit-- === 0) break;

--- a/background.js
+++ b/background.js
@@ -131,10 +131,8 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
             for (const tab of tabs) {
                 if (limit-- === 0) break;
                 let host = new URL(tab.url);
-                let host_str = host.hostname.toString();
-                if (host_str === undefined || host_str.length === 0) {
-                    host_str = "unknown"
-                }
+                let host_str = ColoredTabs.sanitizeHostStr(host.hostname.toString());
+
                 if (tab.id % 10 === 0) {
                     console.log('colorize tab id ' + tab.id + ' host ' + host_str);
                 }
@@ -199,11 +197,14 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
         }
     },
 
-    sanitizeHostStr(_s) {
-        if (typeof _s !== 'string' || tab.url.indexOf('about:') === 0) {
+    sanitizeHostStr(s) {
+        if (typeof s !== 'string' || s.indexOf('about:') === 0) {
+            console.warn("broken host string:", s)
             return "unknown";
         }
-        return _s.slice(0, 100);
+        const final = s.slice(0, 100);
+        console.log("sanitization result", s, final);
+        return final;
     },
 
     hash(_s) {

--- a/background.js
+++ b/background.js
@@ -180,14 +180,19 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
         }
     },
 
-    hash(s) {
+    hash(_s) {
+        if (typeof _s !== 'string') {
+            return 0;
+        }
+        const s = _s.slice(0, 100);
         const cached_value = ColoredTabs.state.hash.get(s);
         if (cached_value !== undefined) {
             return cached_value;
         }
         let h = 0;
-        for (let i = 0, h = 1; i < s.length; i++)
+        for (let i = 0, h = 1; i < s.length; i++) {
             h = Math.imul(h + s.charCodeAt(i) | 0, 2654435761);
+        }
         const result = (h ^ h >>> 17) >>> 0;
         ColoredTabs.state.hash.set(s, cached_value);
         return result;

--- a/background.js
+++ b/background.js
@@ -204,7 +204,7 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
             return "unknown";
         }
         const final = s.slice(0, 100);
-        console.log("sanitization result", s, final);
+        // console.log("sanitization result", s, final);
         return final;
     },
 
@@ -220,7 +220,7 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
         }
         const result = (h ^ h >>> 17) >>> 0;
         ColoredTabs.state.hash.set(s, result);
-        console.log('Calculating color for host', s, result)
+        // console.log('Calculating color for host', s, result)
         return result;
     },
 

--- a/background.js
+++ b/background.js
@@ -84,8 +84,9 @@ let ColoredTabs = {
         console.log(changeInfo);
         if (typeof changeInfo.url === 'undefined' || tab.url.indexOf('about:') === 0)
             return;
-        let host = new URL(changeInfo.url);
-        host = host.hostname.toString();
+        const _host = new URL(changeInfo.url);
+        let host = _host.hostname.toString();
+        host = ColoredTabs.sanitizeHostStr(host);
         if (host !== ColoredTabs.state.tabsHost[tabId]) {
             ColoredTabs.state.tabsHost[tabId] = host;
             ColoredTabs.colorizeTab(tabId, host);
@@ -146,10 +147,7 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
     },
 
     getTabClass(_host) {
-        if (typeof _host !== 'string') {
-            _host = "unknown";
-        }
-        const host = _host.slice(0, 100);
+        const host = ColoredTabs.sanitizeHostStr(_host);
 
         const cached_value = ColoredTabs.state.cache_host_tabclass.get(host);
         if (cached_value !== undefined) {
@@ -201,11 +199,15 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
         }
     },
 
-    hash(_s) {
-        if (typeof _s !== 'string') {
-            return 0;
+    sanitizeHostStr(_s) {
+        if (typeof _s !== 'string' || tab.url.indexOf('about:') === 0) {
+            return "unknown";
         }
-        const s = _s.slice(0, 100);
+        return _s.slice(0, 100);
+    },
+
+    hash(_s) {
+        const s = ColoredTabs.sanitizeHostStr(_s)
         const cached_value = ColoredTabs.state.hash.get(s);
         if (cached_value !== undefined) {
             return cached_value;

--- a/background.js
+++ b/background.js
@@ -249,6 +249,7 @@ async function handleTSTMessage(message, sender) {
         case "ready":
             // TODO worth trying again after a couple of seconds?
             await registerToTST();
+            console.log('Got Ready, calling init');
             ColoredTabs.init();
             break;
         case "sidebar-show":
@@ -261,6 +262,9 @@ async function handleTSTMessage(message, sender) {
                 console.log('ColoredTabs already inited, so call colorizeAllTabs');
                 await ColoredTabs.colorizeAllTabs();
             }
+            break;
+        default:
+            console.log('Unhandled message: ', message);
             break;
     }
 }

--- a/background.js
+++ b/background.js
@@ -126,13 +126,17 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
         });
 
         await browser.tabs.query({}).then(function (tabs) {
+            let limit = 100;
             for (const tab of tabs) {
+                if (limit-- === 0) break;
                 let host = new URL(tab.url);
                 let host_str = host.hostname.toString();
                 if (host_str === undefined || host_str.length === 0) {
                     host_str = "unknown"
                 }
-                console.log('colorize tab id ' + tab.id + ' host ' + host);
+                if (tab.id % 10 === 0) {
+                    console.log('colorize tab id ' + tab.id + ' host ' + host);
+                }
                 ColoredTabs.colorizeTab(tab.id, host);
                 host = null;
                 host_str = null;

--- a/background.js
+++ b/background.js
@@ -218,7 +218,8 @@ tab-item tab-item-substance:hover {filter: saturate(` + ColoredTabs.settings.hov
             h = Math.imul(h + s.charCodeAt(i) | 0, 2654435761);
         }
         const result = (h ^ h >>> 17) >>> 0;
-        ColoredTabs.state.hash.set(s, cached_value);
+        ColoredTabs.state.hash.set(s, result);
+        console.log('Calculating color for host', s, result)
         return result;
     },
 

--- a/files.txt
+++ b/files.txt
@@ -1,0 +1,5 @@
+background.js
+manifest.json
+options.html
+options.js
+sanitizer.js


### PR DESCRIPTION
Concatenate messages to TST with new colors, add awaits and refactor/reformat code.

Starts up faster with 1400+ tabs opened (solving wrong problem here, I know).
Current release clogs up the scheduler with `tabCount` messages, which results in excessive cpu and memory usage for some reason. This PR makes only as much sends as  `colorsUsed`, and awaits for the result . To the smaller extent the performance has improved thanks to the result caching per host.


Still not completed: 
- per tab state handling is needed for the new mass coloring routine;
- chosen colors per host are not working currently;